### PR TITLE
Add RUN chmod +x ApPredict.sh to Dockerfile

### DIFF
--- a/appredict-no-emulators/Dockerfile
+++ b/appredict-no-emulators/Dockerfile
@@ -48,6 +48,7 @@ RUN make -j ${build_processors} ApPredict
 
 RUN mkdir -p ${dir_appredict}
 COPY --chown=appredict:appredict ApPredict.sh ${dir_appredict}/ApPredict.sh
+RUN chmod +x ${dir_appredict}/ApPredict.sh
 
 RUN ln -s ${dir_build}/projects/ApPredict/apps/ApPredict ${dir_appredict}/ 
 


### PR DESCRIPTION
Minor change just so we can consistently invoke dockerized ApPredict via either `appredict-no-emulators` or `appredict-with-emulators`.

(Thought about merging the resultant two sequential `RUN` commands into one but they're unrelated objectives so kept them separate).